### PR TITLE
fixed:

### DIFF
--- a/DataFixtures/ORM/LoadSiteData.php
+++ b/DataFixtures/ORM/LoadSiteData.php
@@ -8,6 +8,7 @@ use Kitpages\CmsBundle\Entity\Site;
 use Kitpages\CmsBundle\Entity\Page;
 use Kitpages\CmsBundle\Entity\PageZone;
 use Kitpages\CmsBundle\Entity\Zone;
+use Doctrine\Common\Persistence\ObjectManager;
 
 class LoadSiteData implements FixtureInterface, ContainerAwareInterface
 {
@@ -17,7 +18,7 @@ class LoadSiteData implements FixtureInterface, ContainerAwareInterface
     {
         $this->container = $container;
     }    
-    public function load($em)
+    public function load(ObjectManager $em)
     {
         $em->getRepository('KitpagesCmsBundle:Site')->set(Site::IS_NAV_PUBLISHED, 0);
         


### PR DESCRIPTION
Fatal error: Declaration of Kitpages\CmsBundle\DataFixtures\ORM\LoadSiteData::load() must be compatible with that of Doctrine\Common\DataFixtures\FixtureInterface::load()
